### PR TITLE
Fixes #12 - "Send all traffic over VPN" CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Creating a single L2TP over IPSec VPN Service:
 
 Replace `--l2tp` with `--cisco` to create a Cisco IPSec instead.  A Cisco IPSec groupname can be specified with `--groupname`.
 
+By default, enables the option "Send all traffic over VPN connection",
+also known as wildcard routing.   To disable this option, include the `--split`
+flag to use the VPN Service for specific routes only.  Split tunnelling may
+require use of [`/etc/ppp/ip-up` and `/etc/ppp/ip-down` scripts](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/pppd.8.html).
+
 #### Shortcuts
 
 The same command but shorter:

--- a/macosvpn/Classes/VPNArguments.m
+++ b/macosvpn/Classes/VPNArguments.m
@@ -95,6 +95,8 @@
 
     config.localIdentifier = [self extractArgumentForSignature:self.localIdentifierSig withFallbackSignature:self.defaultLocalIdentifierSig atIndex:i];
     if (!config.localIdentifier) DDLogWarn(@"Warning: You did not provide a group name for service <%@>", config.name);
+
+    config.enableSplitTunnel = [self.package countOfSignature:self.splitTunnelSig] > 0;
       
     [configs addObject:config];
   }
@@ -125,6 +127,7 @@
     self.defaultPasswordSig, self.passwordSig,
     self.defaultSharedSecretSig, self.sharedSecretSig,
     self.defaultLocalIdentifierSig, self.localIdentifierSig,
+    self.splitTunnelSig,
   nil];
 
   [command setInjectedSignatures:createSignatures];
@@ -143,6 +146,10 @@
 
 + (FSArgumentSignature*) versionSig {
   return [FSArgumentSignature  argumentSignatureWithFormat:@"[-v --version version]"];
+}
+
++ (FSArgumentSignature*) splitTunnelSig {
+    return [FSArgumentSignature argumentSignatureWithFormat:@"[-x --split split]"];
 }
 
 // Internal: Interface Arguments
@@ -180,6 +187,7 @@
 + (FSArgumentSignature*) defaultSharedSecretSig {
   return [FSArgumentSignature argumentSignatureWithFormat:@"[-t --defaultsharedsecret defaultsharedsecret]="];
 }
+
 + (FSArgumentSignature*) defaultLocalIdentifierSig {
     return [FSArgumentSignature argumentSignatureWithFormat:@"[-t --defaultgroupname defaultgroupname]="];
 }
@@ -220,7 +228,7 @@
     self.helpSig,
     self.debugSig,
     self.versionSig,
-    self.createCommandSig,
+    self.createCommandSig
   ];
 }
 

--- a/macosvpn/Classes/VPNServiceConfig.h
+++ b/macosvpn/Classes/VPNServiceConfig.h
@@ -26,6 +26,7 @@
 @property (strong) NSString *password;
 @property (strong) NSString *sharedSecret;
 @property (strong) NSString *localIdentifier;
+@property (atomic) BOOL enableSplitTunnel;
 
 @property (readonly) NSString *humanType;
 

--- a/macosvpn/Classes/VPNServiceConfig.m
+++ b/macosvpn/Classes/VPNServiceConfig.m
@@ -94,14 +94,16 @@
   keys[count] = kSCPropNetIPv4ConfigMethod;
   vals[count++] = kSCValNetIPv4ConfigMethodPPP;
 
-  int one = 1;
-  keys[count] = kSCPropNetOverridePrimary;
+  if (!self.enableSplitTunnel) {
+    int one = 1;
+    keys[count] = kSCPropNetOverridePrimary;
 
-  // X-Code warns on this (CFString VS. CFNumber), but it should not matter, CFNumber is the correct type I think, as you can verify in the resulting /Library/Preferences/SystemConfiguration/preferences.plist file.
-  // See also https://developer.apple.com/library/prerelease/ios/documentation/CoreFoundation/Conceptual/CFPropertyLists/Articles/Numbers.html
-  #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
-  vals[count++] = CFNumberCreate(NULL, kCFNumberIntType, &one);
-  #pragma clang diagnostic pop
+    // X-Code warns on this (CFString VS. CFNumber), but it should not matter, CFNumber is the correct type I think, as you can verify in the resulting /Library/Preferences/SystemConfiguration/preferences.plist file.
+    // See also https://developer.apple.com/library/prerelease/ios/documentation/CoreFoundation/Conceptual/CFPropertyLists/Articles/Numbers.html
+    #pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+    vals[count++] = CFNumberCreate(NULL, kCFNumberIntType, &one);
+    #pragma clang diagnostic pop
+  }
 
   return CFDictionaryCreate(NULL, (const void **)&keys, (const void **)&vals, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 }


### PR DESCRIPTION
Adds optional CLI arg `--split-tunnel` to uncheck the
"Send all traffic over VPN connection" setting in the created
VPN service.  For backwards compatibility, this program will
continue to enable the setting unless this new `--split-tunnel` arg
is used.