### PR TITLE
Add nil check for VPN password and shared secret

### DIFF
--- a/macosvpn/Classes/VPNController.m
+++ b/macosvpn/Classes/VPNController.m
@@ -255,8 +255,13 @@
   // The password and the shared secret are not stored directly in the System Preferences .plist file
   // Instead we put them into the KeyChain. I know we're creating new items each time you run this application
   // But this actually is the same behaviour you get using the official System Preferences Network Pane
-  [VPNKeychain createPasswordKeyChainItem:config.name forService:serviceID withAccount:config.username andPassword:config.password];
-  [VPNKeychain createSharedSecretKeyChainItem:config.name forService:serviceID withPassword:config.sharedSecret];
+  if (config.password) {
+    [VPNKeychain createPasswordKeyChainItem:config.name forService:serviceID withAccount:config.username andPassword:config.password];
+  }
+
+  if (config.sharedSecret) {
+    [VPNKeychain createSharedSecretKeyChainItem:config.name forService:serviceID withPassword:config.sharedSecret];
+  }
 
   if (!SCPreferencesApplyChanges(prefs)) {
     DDLogError(@"Error: Could not apply changes with service %@. %s (Code %i)", config.name, SCErrorString(SCError()), SCError());


### PR DESCRIPTION
Fixes an issue where below would fail to create the shared IPSec
secret due to a lack of the `--password` CLI argument:

```
macosvpn create --l2tp example --endpoint vpn.example.com \
  --username user@example.com --shared-secret mysecret
```

Without this patch, the final 5 lines `--debug` lines are missing from
the end of the debug output:

```
   Succeeded opening System Keychain
   Unlocking System Keychain
   Succeeded unlocking System Keychain
-  Created empty Keychain access object
-  Successfully created Keychain Item
-  Successfully created L2TP over IPSec VPN example with ID
:some_random_uuid
-
-  Finished.
```

This patch enables creation of a VPN Service which requires a
shared secret but will prompt the end user for their password.
This is helpful for Single Sign On (SSO) situations where the
user is forced to change their passphrase every X days, and saving
the password in the VPN Service will likely lead to account
lockouts due to repeated attempts to use an old passphrase.